### PR TITLE
当syntax为simple或native时,不进行路径转换

### DIFF
--- a/bin/tmod
+++ b/bin/tmod
@@ -195,7 +195,7 @@ if (options.output) {
     options.output = path.relative(dir, path.resolve(options.output));
 }
 
-if (options.syntax) {
+if (options.syntax && options.syntax != 'simple' && options.syntax != 'native') {
     options.syntax = path.relative(dir, path.resolve(options.syntax));
 }
 


### PR DESCRIPTION
目前使用cli方式使用tmod时, 设置syntax时, 会对simple 或native 两种方式也进行path.resolve, 使得无法进行native方式. 

因此当判断 syntax 为native 或simple方式时, 不进行文件路径查找

fix #17 
