### PR TITLE
解决多个Tmod实例运行的异常

### DIFF
--- a/src/tmod.js
+++ b/src/tmod.js
@@ -57,6 +57,10 @@ var Tmod = function (base, options) {
     this.runtime = path.resolve(this.output, options.runtime);
 
 
+    // 编译结果存储
+    this._cache = {};
+
+
     // 清理模板项目临时文件
     this._clear();
 
@@ -1075,9 +1079,6 @@ Tmod.prototype = {
     _getByteLength: function (content) {
         return content.replace(/[^\x00-\xff]/gi, '--').length;
     },
-
-
-    _cache: {},
 
 
     // 获取缓存


### PR DESCRIPTION
将原先放在prototype上的_cache属性改到this上面，防止多个实例的数据混在一起，例如要build两个目录的话，第二个目录的编译结果会包含第一个目录的结果
