### PR TITLE
修复AMD打包空字符串依赖问题

### DIFF
--- a/src/AOTcompile.js
+++ b/src/AOTcompile.js
@@ -98,7 +98,7 @@ module.exports = function (template) {
 
                 code
                 = "define("
-                + "['" + getRuntime() + "','" + requires.join("','") + "'],"
+                + (requires.length > 0 )? "['" + getRuntime() + "','" + requires.join("','") + "']," : "['" + getRuntime() + "'],"
                 + "function(template){"
                 +      "return template('" + filename + "', " + code + ");"  
                 + "});";


### PR DESCRIPTION
问题如https://github.com/aui/tmodjs/issues/77 描述，在模板中没有依赖其他模板的情况下，去掉打包后的define里面多一个空字符串依赖项的问题。我在Dojo中使用AMD打包形式的模板的时候也遇到了这个错误。