### PR TITLE
修复AMD打包空字符串依赖问题

### DIFF
--- a/src/AOTcompile.js
+++ b/src/AOTcompile.js
@@ -95,10 +95,10 @@ module.exports = function (template) {
 
             // RequireJS 模块格式
             case 'amd':
-
+                var dependencies = (requires.length > 0 )? "['" + getRuntime() + "','" + requires.join("','") + "']," : "['" + getRuntime() + "'],";
                 code
                 = "define("
-                + (requires.length > 0 )? "['" + getRuntime() + "','" + requires.join("','") + "']," : "['" + getRuntime() + "'],"
+                + dependencies
                 + "function(template){"
                 +      "return template('" + filename + "', " + code + ");"  
                 + "});";

--- a/src/AOTcompile.js
+++ b/src/AOTcompile.js
@@ -98,7 +98,7 @@ module.exports = function (template) {
 
                 code
                 = "define("
-                + "['" + getRuntime() + "','" + requires.join("','") + "'],"
+                + (requires.length > 0 )? "['" + getRuntime() + "','" + requires.join("','") + "']," : "['" + getRuntime() + "'],"
                 + "function(template){"
                 +      "return template('" + filename + "', " + code + ");"  
                 + "});";


### PR DESCRIPTION
直接在字符串里面判断会出现bug，改为使用变量保存字符串，再拼接。