### PR TITLE
增加output设置为false的情况

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ TmodJS 的项目配置文件保存在模板目录的 package.json 文件中：
 
 字段 | 类型 | 默认值| 说明
 ------------ | ------------- | ------------ | ------------
-output | String | ``"./build"`` | 编译输出目录设置
+output | String | ``"./build"`` | 编译输出目录设置。如果设置为 false 则不输出
 charset | String | ``"utf-8"`` | 模板使用的编码（暂时只支持 utf-8）
 syntax | String | ``"simple"`` | 定义模板采用哪种语法。可选：``simple``、``native``
 helpers | String | ``null`` | 自定义辅助方法路径
@@ -170,6 +170,7 @@ alias | String | ``null`` | 设置模块依赖的运行时路径（仅针对于�
 combo | Boolean | ``true`` | 是否合并模板（仅针对于 default 类型的模块）
 minify | Boolean | ``true`` | 是否输出为压缩的格式
 cache | Boolean | ``true`` | 是否开启编译缓存
+verbose | Boolean | ``true`` | 是否打印日志
 	
 ##	grunt
 
@@ -242,6 +243,11 @@ npm install gulp-tmod --save-dev
 > 编辑配置文件，设置``combo:false``。
 
 ##	更新日志
+
+### v1.0.4 
+
+*   设置``"output":false``则不进行输出，方便Gulp插件利用
+*   新增``"verbose": true``选项，选择是否显示日志
 
 ### v1.0.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tmodjs",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "readmeFilename": "README.md",
     "description": "Template Compiler",
     "homepage": "https://github.com/aui/tmodjs",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -46,6 +46,9 @@ module.exports = {
     minify: true,
 
     // 是否开启编译缓存
-    cache: true
+    cache: true,
+
+    // 是否输出日志
+    verbose: true
 
 };

--- a/src/tmod.js
+++ b/src/tmod.js
@@ -724,9 +724,11 @@ Tmod.prototype = {
             }
 
 
-            if (this.options.debug || !this.options.minify) {
+            if (this.options.debug) {
                 this._beautify(this.runtime);
-            } else {
+            }
+
+            if (!this.options.debug && this.options.minify) {
                 this._minify(this.runtime);
             }
         }
@@ -991,9 +993,11 @@ Tmod.prototype = {
 
 
                 if (!isCacheDir && !writeError) {
-                    if (isDebug || !this.options.minify) {
+                    if (isDebug) {
                         this._beautify(target);
-                    } else {
+                    }
+
+                    if (!isDebug && this.options.minify) {
                         this._minify(target);
                     }
                 }

--- a/src/tmod.js
+++ b/src/tmod.js
@@ -713,7 +713,7 @@ Tmod.prototype = {
         });
 
 
-        this.runtimeCode = runtimeCode = this._setMetadata(runtimeCode, metadata);
+        runtimeCode = this._setMetadata(runtimeCode, metadata);
 
         if (this.options.output !== false) {
             try {


### PR DESCRIPTION
为了让[gulp-tmod](https://github.com/calledT/gulp-tmod)符合gulp插件规范，不用tomdjs自带的output，所以增加`output === false`的判断，从而不产生文件。

另外增加了一个`verbose`的选项用来控制是否显示日志。

还有修改了_beautify和_minify执行的判断逻辑，不总是非得二选一，这样有利于gulp插件的测试用例对比字符串