### PR TITLE
修正因v1.0.4版本新增的是否显示日志选项，在tmodjs初始化过程中产生的bug

### DIFF
--- a/src/tmod.js
+++ b/src/tmod.js
@@ -232,10 +232,13 @@ Tmod.prototype = {
 
         //有些项目的package.json里只有devDependencies而没有dependencies
         //那么下面的replace那行代码就会出现can't read property 'tmodjs' of undefined的错误
-        //这里添加容错逻辑
-
-        if (!json.dependencies) {
-            json.dependencies = json.devDependencies;
+        //这里添加容错逻辑，如果devDependencies里面也没有tmodjs就结束运行。
+        if (!json.dependencies.tmodjs) {
+            if (!json.devDependencies.tmodjs) {
+                this.log('[red]can\'t read property "tmodjs" of undefined in package.json![/red]\n');
+                process.exit(1);
+            }
+            json.dependencies.tmodjs = json.devDependencies.tmodjs;
         }
 
         var targetVersion = json.dependencies.tmodjs.replace(/^~/, '');
@@ -507,7 +510,10 @@ Tmod.prototype = {
      * @param   {String}    消息
      */
     log: function (message) {
-        if (this.options.verbose) {
+        var verbose = (typeof this.options === 'undefined' && Tmod.defaults.verbose)
+            || this.options.verbose;
+
+        if (verbose) {
             stdout(message);
         }
     },


### PR DESCRIPTION
fix：
1、tmod在实例化过程中，获取package.json中依赖tmodjs版本号时的容错逻辑有判断遗漏，假如在dependencies中没有tmodjs的依赖，但是有其他第三方模块的依赖，而devDependencies中有tmodjs，但是没有对其进行容错处理，导致后续的replace出现can't read property 'tmodjs' of undefined的错误，也给第三方工具的集成造成不便。
2、v1.0.4新增"verbose": true选项，选择是否显示日志，产生的bug，主要是当tmod在获取配置信息时，这个时候tmodjs内部的options属性并未初始化，而获取配置信息出错时，调用打印日志的前提是判断this.options.verbose为真时才打印，此时this.options是没有初始化的，那么这就尴尬了，直接就出现'verbose' of undefined'，使用者连为何错误都不知道。
虽然项目停更了，如果作者觉得合理，希望作者能合并这个请求。